### PR TITLE
Add GitHub Copilot extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "GitHub Copilot Devcontainer",
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+    "extensions": [
+        "GitHub.copilot"
+    ],
+    "settings": {
+        "github.copilot.enable": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # github-copilot-active-adoption
+
+## Codespaces Devcontainer and GitHub Copilot Extension
+
+This repository includes a devcontainer configuration for use with GitHub Codespaces. The devcontainer is pre-configured with the GitHub Copilot extension to help you write code faster and more efficiently.
+
+### How to Use the Devcontainer with GitHub Copilot
+
+1. Open this repository in GitHub Codespaces.
+2. When prompted, open the project in the devcontainer.
+3. The GitHub Copilot extension should be automatically installed and activated.
+4. Start writing code and let GitHub Copilot assist you with code suggestions and completions.


### PR DESCRIPTION
Add GitHub Copilot extension to devcontainer configuration.

* **README.md**
  - Add a section about Codespaces devcontainer and GitHub Copilot extension.
  - Provide instructions on how to use the devcontainer with GitHub Copilot.

* **.devcontainer/devcontainer.json**
  - Create a new devcontainer configuration file.
  - Add the necessary settings to include the GitHub Copilot extension.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/a-shinba/github-copilot-active-adoption/pull/1?shareId=24c80041-82bc-43e4-9bb1-f86138a1c3f8).